### PR TITLE
Fixed Flakiness in JSON assertion

### DIFF
--- a/infra/jreleaser-test-support/src/main/java/org/jreleaser/test/WireMockStubs.java
+++ b/infra/jreleaser-test-support/src/main/java/org/jreleaser/test/WireMockStubs.java
@@ -57,6 +57,6 @@ public final class WireMockStubs {
         maybeJson = maybeJson.trim().replaceAll("\\r\\n", "\\n");
         verify(builder.withHeader("Content-Type", containing("application/json"))
             .withHeader("Accept", or(equalTo("*/*"), equalTo("application/json")))
-            .withRequestBody(maybeJson.startsWith("{") ? containing(maybeJson.substring(1, maybeJson.length() - 1)) : containing(maybeJson)));
+            .withRequestBody(equalToJson(maybeJson)));
     }
 }


### PR DESCRIPTION
Fixes [#1527](https://github.com/jreleaser/jreleaser/issues/1527)

**Module**: jreleaser-linkedin-java-sdk
**Tests:** 
org.jreleaser.sdk.linkedin.LinkedinSdkTest.testMessageWithExplicitOwner
org.jreleaser.sdk.linkedin.LinkedinSdkTest.testMessageWithImplicitOwner

### Root Cause
The tests compares an API response output with hardcoded JSON string and verifies if they are equal. However, the comparision of JSON could be non-deterministic since JSON objects do not necessarily maintain the order of key:value pairs. Since the current test expects order to be maintained, the test can fail. we can use [Nondex](https://github.com/TestingResearchIllinois/nondex) Tool to detect the flakiness in test.

### Fix
utilized equalToJson  which compares the two JSON strings ignoring the order of the contents.

### Checklist
- [X] [Review Contribution Guidelines](https://github.com/jreleaser/jreleaser/blob/master/CONTRIBUTING.adoc).
- [X] Make sure all contributed code can be distributed under the terms of the 
      [Apache License 2.0](https://github.com/jreleaser/jreleaser/blob/master/LICENSE), e.g. the code was written by 
      you or the original code is licensed under [a license compatible to Apache License 2.0](https://apache.org/legal/resolved.html).
- [ ] Update [documentation](https://github.com/jreleaser/jreleaser.github.io) when applicable.
